### PR TITLE
202306011630 프로젝트: 다람쥐 버그 픽스

### DIFF
--- a/BN/ProjectSquirrel/advtech/sq_nano_tier.json
+++ b/BN/ProjectSquirrel/advtech/sq_nano_tier.json
@@ -38,8 +38,8 @@
     "charges_per_use": 1,
     "use_action": [ {
       "type": "transform",
-      "msg": "타입-보이의 손전등 모드를 켰다.",
-      "target": "sq_typeboy_on",
+      "msg": "타입-보이의 바이오닉 스캐너 모드를 켰다.",
+      "target": "sq_typeboy_bionic",
       "active": true,
       "need_charges": 1,
       "need_charges_msg": "타입-보이의 배터리가 방전되었다."
@@ -50,7 +50,17 @@
 	"terrain": ["hiway", "road"],
 	"message": "You add roads and tourist attractions to your map."
 	},
-    "RADGLOVE", "DIRECTIONAL_ANTENNA", "EINKTABLETPC", "NOTE_BIONICS", "PORTABLE_GAME", "WEATHER_TOOL" ]
+    "RADGLOVE", "DIRECTIONAL_ANTENNA", "EINKTABLETPC", "PORTABLE_GAME", "WEATHER_TOOL" ]
+  },
+  {
+    "id": "sq_typeboy_bionic",
+    "copy-from": "sq_typeboy",
+    "type": "TOOL_ARMOR",
+    "name": { "str": "타입-보이 (바이오닉 탐지)", "str_pl": "타입-보이 (바이오닉 탐지)" },
+    "revert_to": "sq_typeboy",
+    "use_action": [ { "menu_text": "손전등 모드", "type": "transform", "msg": "타입-보이의 손전등 모드를 켰다.", "target": "sq_typeboy_on" }, "NOTE_BIONICS" ],
+    "revert_msg": "타입-보이를 껐다.",
+    "flags": [ "TRADER_AVOID" ]
   },
   {
     "id": "sq_typeboy_on",


### PR DESCRIPTION
## 타입-보이 버그 수정
타입-보이의 바이오닉 스캐너 설정이 작동하지 않는 버그를 수정했습니다.
바이오닉 스캐너 기능을 단순히 use_action에 붙인다고 되는 게 아니라 작동하는 물건에다 따로 집어넣어야함
+ off>바이오닉 스캐너>손전등>off 순으로 순차적으로 작동하게 만듦
+ 손전등은 무한광원이 됨. 대신 원자력 헤드램프 레시피처럼 플루토늄 연료전지를1개 먹음