### PR TITLE
202308110338 프로젝트: 다람쥐 제작도구 간소화

### DIFF
--- a/BN/ProjectSquirrel/advtech/sq_advanced_armor.json
+++ b/BN/ProjectSquirrel/advtech/sq_advanced_armor.json
@@ -144,7 +144,7 @@
     "skills_required": [ [ "fabrication", 10 ], [ "electronics", 5 ], [ "mechanics", 6 ] ],
     "time": "2 h 30 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "welding_standard", 21 ] ],
     "components": [
       [ [ "small_storage_battery", 1 ] ],
@@ -894,7 +894,7 @@
     "skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "3 h 30 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 42 ] ],
     "components": [
       [ [ "plasma", 25 ] ],
@@ -921,7 +921,7 @@
     "skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "3 h 30 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 42 ] ],
     "components": [
       [ [ "plasma", 25 ] ],
@@ -951,7 +951,7 @@
     "skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "3 h 30 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 42 ] ],
     "components": [
       [ [ "plasma", 25 ] ],

--- a/BN/ProjectSquirrel/advtech/sq_advanced_armor_colors.json
+++ b/BN/ProjectSquirrel/advtech/sq_advanced_armor_colors.json
@@ -229,7 +229,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -244,7 +244,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -259,7 +259,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -274,7 +274,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -289,7 +289,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -304,7 +304,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -319,7 +319,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -334,7 +334,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -349,7 +349,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -364,7 +364,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -379,7 +379,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -394,7 +394,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -409,7 +409,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -424,7 +424,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -439,7 +439,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -454,7 +454,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -469,7 +469,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -484,7 +484,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -499,7 +499,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -514,7 +514,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -529,7 +529,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -544,7 +544,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -559,7 +559,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -574,7 +574,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -589,7 +589,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -604,7 +604,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -619,7 +619,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -634,7 +634,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -649,7 +649,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]
@@ -664,7 +664,7 @@
 	"skills_required": [ [ "mechanics", 10 ], [ "electronics", 10 ], [ "computer", 10 ] ],
     "time": "5 m",
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_cvdmachine", -1 ] ], [ [ "sq_nanofab", -1 ] ] ],
     "components": [
 	  [ [ "nanomaterial", 5 ] ]
     ]

--- a/BN/ProjectSquirrel/advtech/sq_hardlight_fusion.json
+++ b/BN/ProjectSquirrel/advtech/sq_hardlight_fusion.json
@@ -580,7 +580,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -628,7 +628,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 4 ] ],
@@ -678,7 +678,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 3 ] ],
@@ -728,7 +728,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 4 ] ],
@@ -780,7 +780,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 6 ] ],
@@ -840,7 +840,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_hardlight", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -944,7 +944,7 @@
       { "id": "HAMMER", "level": 2 }
     ],
     "tools": [
-      [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ],
+      [ [ "sq_atomic_forge", -1 ] ],
       [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ],
       [ [ "welder", 200 ], [ "oxy_torch", 40 ], [ "welder_crude", 300 ], [ "toolset", 300 ] ],
       [ [ "soldering_iron", 50 ], [ "toolset", 50 ] ]
@@ -1014,7 +1014,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -1081,7 +1081,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -1149,7 +1149,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],
@@ -1215,7 +1215,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 4 ] ],
@@ -1282,7 +1282,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 4 ] ],
@@ -1357,7 +1357,7 @@
     "autolearn": false,
     "book_learn": [ [ "sq_recipe_lab_fusion", 10 ] ],
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "components": [
       [ [ "amplifier", 2 ] ],

--- a/BN/ProjectSquirrel/advtech/sq_main_tools.json
+++ b/BN/ProjectSquirrel/advtech/sq_main_tools.json
@@ -52,6 +52,7 @@
     "symbol": ";",
     "looks_like": "minireactor",
     "color": "light_green",
+    "qualities": [ [ "FINE_DISTILL", 1 ], [ "CONCENTRATE", 1 ], [ "SEPARATE", 1 ], [ "ANALYSIS", 1 ] ],
     "flags": [ "LIGHT_1", "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -115,7 +116,7 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "recipe_lab_elec", 9 ], [ "textbook_robots", 10 ] ],
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "soldering_standard", 40 ], [ "welding_standard", 20 ] ],
     "qualities": [
       { "id": "GLARE", "level": 2 },
@@ -173,7 +174,7 @@
     "reversible": false,
     "autolearn": true,
     "book_learn": [ [ "textbook_mechanics", 6 ], [ "recipe_lab_cvd", 9 ], [ "recipe_lab_elec", 9 ], [ "textbook_atomic_lab", 7 ] ],
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "welding_standard", 15 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
@@ -192,60 +193,6 @@
       [ [ "amplifier", 2 ] ],
       [ [ "plastic_chunk", 6 ] ],
       [ [ "small_storage_battery", 1 ] ]
-    ]
-  },
-  {
-    "id": "sq_rtg_forge",
-    "type": "TOOL",
-    "category": "tools",
-    "name": { "str": "동위원소 원심분리 용광로" },
-    "description": "원자력 용광로 겸 회전 원심분리기. 액체납으로 차폐한 이중관과 이중용기로 이루어진 전기먹는 하마입니다. 유해 폐기물 석관이나 유독성 물질 폐기장의 핵폐기물을 재활용하여 농축 우라늄 용기 및 우라늄 연료전지의 제작이 가능하며, 본격적인 핵연료의 이용과 추출이 가능해집니다. \n다음 업그레이드: 우라늄 증식 용광로\n",
-    "weight": "23500 g",
-    "volume": "8 L",
-    "price": 4000000,
-    "price_postapoc": 40000,
-    "to_hit": -2,
-    "bashing": 8,
-    "material": [ "steel", "aluminum" ],
-    "symbol": ";",
-    "looks_like": "minireactor",
-    "color": "red",
-    "qualities": [ [ "FINE_DISTILL", 1 ], [ "CONCENTRATE", 1 ], [ "SEPARATE", 1 ], [ "ANALYSIS", 1 ] ],
-    "flags": [ "LIGHT_1", "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
-  },
-  {
-    "result": "sq_rtg_forge",
-    "type": "recipe",
-    "category": "CC_첨단기술",
-    "subcategory": "CSC_첨단기술_TOOLS",
-    "skill_used": "electronics",
-    "skills_required": [ [ "mechanics", 7 ], [ "electronics", 7 ], [ "computer", 7 ], [ "cooking", 7 ] ],
-    "difficulty": 9,
-    "time": "5 h",
-    "reversible": true,
-    "autolearn": true,
-    "tools": [ [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
-    "using": [ [ "welding_standard", 20 ] ],
-    "qualities": [
-      { "id": "GLARE", "level": 2 },
-      { "id": "HAMMER", "level": 2 },
-      { "id": "SAW_M", "level": 2 },
-      { "id": "SCREW", "level": 1 },
-      { "id": "WRENCH", "level": 2 },
-      { "id": "CHISEL", "level": 3 },
-      { "id": "DRILL", "level": 3 },
-      { "id": "GRIND", "level": 2 }
-    ],
-    "components": [
-      [ [ "lead", 100 ] ],
-      [ [ "sq_atomic_forge", 1 ] ],
-      [ [ "nanomaterial", 50 ] ],
-      [ [ "motor_small", 1 ] ],
-      [ [ "power_supply", 5 ] ],
-      [ [ "alloy_plate", 2 ] ],
-      [ [ "plasma", 10 ] ],
-      [ [ "plut_cell", 4 ] ],
-      [ [ "analytical_set_basic", 1 ] ]
     ]
   },
   {
@@ -316,7 +263,7 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "textbook_atomic_lab", 8 ], [ "recipe_lab_cvd", 9 ], [ "recipe_lab_elec", 9 ] ],
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
@@ -388,7 +335,7 @@
     "reversible": true,
     "autolearn": false,
     "book_learn": [ [ "recipe_lab_elec", 6 ], [ "recipe_lab_cvd", 8 ] ],
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
@@ -410,93 +357,6 @@
       [ [ "amplifier", 4 ] ],
       [ [ "plastic_chunk", 10 ] ],
       [ [ "small_storage_battery", 1 ] ]
-    ]
-  },
-  {
-    "id": "sq_uranium_forge_done",
-    "type": "GENERIC",
-    "category": "tools",
-    "name": { "str": "우라늄 증식 용광로 (증식 완료)" },
-	"looks_like": "sq_uranium_forge",
-    "description": "우라늄 증식 용광로가 농축 우라늄 생산 절차를 마쳤습니다. 분해하여 회수하십시오.",
-    "weight": "23500 g",
-    "volume": "12 L",
-    "price": 100,
-    "price_postapoc": 500,
-    "to_hit": -2,
-    "material": [ "steel", "superalloy" ],
-    "symbol": ";",
-    "color": "yellow",
-    "use_action": "DISASSEMBLE",
-    "flags": [ "NO_REPAIR", "NO_SALVAGE" ]
-  },
-  {
-    "result": "sq_uranium_forge_done",
-    "type": "uncraft",
-    "skill_used": "electronics",
-    "difficulty": 7,
-    "time": "180 s",
-    "components": [
-	[ [ "sq_uranium_condensed", 1 ] ],
-	[ [ "sq_uranium_forge", 1 ] ]
-	]
-  },
-  {
-    "id": "sq_uranium_forge",
-    "type": "GENERIC",
-    "category": "tools",
-    "name": { "str": "우라늄 증식 용광로" },
-    "description": "우라늄-235의 핵융합을 기반으로 한 용광로는 플루토늄 연료전지를 대체하고, 사용(a)로 지속적으로 농축 우라늄을 생성할 수 있는 혁신적인 에너지 시스템입니다. 방사능과 전자파가 우려된다면서 발전소를 반대하는 사람들도 있었죠. 그 사람들이 이걸 보면 뭐라고 생각할까요?",
-    "weight": "23500 g",
-    "volume": "12 L",
-    "price": 4000000,
-    "price_postapoc": 40000,
-    "to_hit": -2,
-    "bashing": 8,
-    "material": [ "steel", "superalloy" ],
-    "symbol": ";",
-    "looks_like": "minireactor",
-    "color": "yellow",
-    "use_action": {
-      "target": "sq_uranium_forge_done",
-      "msg": "용광로의 우라늄이 가득 찼다. 이제 꺼내야 할 시간이다.",
-      "moves": 0,
-      "type": "delayed_transform",
-      "transform_age": 3600,
-      "not_ready_msg": "용광로의 우라늄이 아직 증식하는 중이다."
-    },
-    "qualities": [ [ "FINE_DISTILL", 1 ], [ "CONCENTRATE", 1 ], [ "SEPARATE", 1 ], [ "ANALYSIS", 1 ] ],
-    "flags": [ "LIGHT_1", "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
-  },
-  {
-    "result": "sq_uranium_forge",
-    "type": "recipe",
-    "category": "CC_첨단기술",
-    "subcategory": "CSC_첨단기술_TOOLS",
-    "skill_used": "electronics",
-    "skills_required": [ [ "mechanics", 7 ], [ "electronics", 7 ], [ "computer", 7 ], [ "cooking", 7 ] ],
-    "difficulty": 9,
-    "time": "5 h",
-    "autolearn": true,
-    "using": [ [ "welding_standard", 20 ] ],
-    "qualities": [
-      { "id": "GLARE", "level": 2 },
-      { "id": "HAMMER", "level": 2 },
-      { "id": "SAW_M", "level": 2 },
-      { "id": "SCREW", "level": 1 },
-      { "id": "WRENCH", "level": 2 },
-      { "id": "CHISEL", "level": 3 },
-      { "id": "DRILL", "level": 3 },
-      { "id": "GRIND", "level": 2 }
-    ],
-    "components": [
-      [ [ "lead", 1000 ] ],
-      [ [ "metal_tank", 1 ] ],
-      [ [ "sq_rtg_forge", 1 ] ],
-      [ [ "nanomaterial", 50 ] ],
-      [ [ "power_supply", 5 ] ],
-      [ [ "alloy_plate", 2 ] ],
-      [ [ "sq_uranium_cell", 2 ] ]
     ]
   },
   {
@@ -562,7 +422,7 @@
     "reversible": true,
     "autolearn": true,
     "book_learn": [ [ "textbook_mechanics", 6 ], [ "recipe_lab_cvd", 9 ] ],
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "welding_standard", 20 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },

--- a/BN/ProjectSquirrel/advtech/sq_nano_generic_comp.json
+++ b/BN/ProjectSquirrel/advtech/sq_nano_generic_comp.json
@@ -114,7 +114,7 @@
     "batch_time_factors": [ 50, 5 ],
     "book_learn": [ [ "recipe_lab_cvd", 8 ], [ "textbook_chemistry", 6 ], [ "adv_chemistry", 6 ], [ "recipe_labchem", 7 ] ],
     "autolearn": false,
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "components": [ [ [ "ash", 200 ], [ "charcoal", 10 ] ] ]
   },
   {
@@ -146,7 +146,7 @@
     "book_learn": [ [ "recipe_lab_cvd", 7 ] ],
     "autolearn": false,
 	"charges": 2,
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "components": [ [ [ "resin_chunk", 1 ] ], [ [ "graphene", 30 ] ] ]
   },
   {
@@ -163,7 +163,7 @@
     "book_learn": [ [ "recipe_lab_cvd", 7 ] ],
     "autolearn": false,
 	"charges": 10,
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "components": [ [ [ "alien_pod_resin", 1 ] ], [ [ "graphene", 3 ] ] ]
   },
   {
@@ -233,7 +233,7 @@
     "book_learn": [ [ "recipe_labchem", 8 ], [ "textbook_atomic_lab", 7 ] ],
     "autolearn": true,
     "tools": [
-      [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ],
+      [ [ "sq_atomic_forge", -1 ] ],
       [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ]
     ],
     "components": [ [ [ "nanomaterial", 5 ] ], [ [ "graphene", 2 ] ], [ [ "steel_lump", 1 ] ] ]
@@ -292,7 +292,7 @@
     "book_learn": [ [ "recipe_labchem", 8 ], [ "recipe_atomic_battery", 7 ] ],
     "autolearn": true,
     "tools": [
-      [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ],
+      [  [ "sq_atomic_forge", -1 ] ],
       [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ]
     ],
     "qualities": [ { "id": "FINE_DISTILL", "level": 1 }, { "id": "CONCENTRATE", "level": 1 }, { "id": "SEPARATE", "level": 1 } ],
@@ -311,7 +311,7 @@
     "time": "60 m",
     "book_learn": [ [ "recipe_labchem", 8 ], [ "recipe_atomic_battery", 7 ] ],
     "autolearn": true,
-    "tools": [ [ [ "sq_uranium_forge", -1 ] ], [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ], [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ] ],
     "qualities": [ { "id": "FINE_DISTILL", "level": 1 }, { "id": "CONCENTRATE", "level": 1 }, { "id": "SEPARATE", "level": 1 } ],
     "components": [ [ [ "sq_uranium_condensed", 1 ] ] ]
   },
@@ -380,7 +380,7 @@
     "time": 30000,
     "book_learn": [ [ "recipe_atomic_battery", 7 ] ],
     "autolearn": true,
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [  [ "sq_atomic_forge", -1 ] ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [
       [ [ "canister_empty", 1 ] ],
@@ -400,7 +400,7 @@
     "time": 30000,
     "book_learn": [ [ "recipe_atomic_battery", 5 ] ],
     "autolearn": true,
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [  [ "sq_atomic_forge", -1 ] ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [
       [ [ "canister_empty", 1 ] ],
@@ -422,7 +422,7 @@
     "time": 30000,
     "book_learn": [ [ "recipe_atomic_battery", 5 ] ],
     "autolearn": true,
-    "tools": [ [ [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [  [ "sq_atomic_forge", -1 ] ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [
       [ [ "sq_uranium_cell", 1 ] ],

--- a/BN/ProjectSquirrel/advtech/sq_nano_tier.json
+++ b/BN/ProjectSquirrel/advtech/sq_nano_tier.json
@@ -332,6 +332,18 @@
     }
   },
   {
+    "type": "effect_type",
+    "id": "sq_nanobandages_effect",
+    "name": [ "나노붕대 치유" ],
+    "desc": [ "나노포장 붕대를 적용했습니다. 상처가 빠른 속도로 치유됩니다." ],
+    "apply_message": "상처가 빠른 속도로 아뭅니다. 조금 아프네요.",
+    "rating": "good",
+	"main_parts_only": true,
+    "base_mods": { "hurt_amount": [ -20 ] },
+    "show_in_info": true,
+    "blood_analysis_description": "나노 치유"
+  },
+  {
     "result": "sq_nanobandages",
     "type": "recipe",
     "category": "CC_첨단기술",
@@ -347,16 +359,6 @@
       [ [ "duct_tape", 20 ], [ "medical_tape", 5 ] ],
       [ [ "disinfectant", 5 ], [ "thyme_oil", 1 ], [ "chem_ethanol", 250 ], [ "denat_alcohol", 250 ] ]
     ]
-  },
-  {
-    "type": "effect_type",
-    "id": "sq_nanobandages_effect",
-    "name": [ "나노붕대 치유" ],
-    "desc": [ "나노포장 붕대를 적용했습니다. 상처가 빠른 속도로 치유됩니다." ],
-    "apply_message": "상처가 빠른 속도로 아뭅니다. 조금 아프네요.",
-    "rating": "good",
-    "base_mods": { "hurt_amount": [ -20 ] },
-    "blood_analysis_description": "나노 치유"
   },
   {
     "type": "mutation",
@@ -482,7 +484,7 @@
     "time": "4 h",
     "book_learn": [ [ "textbook_weapwest", 10 ], [ "scots_cookbook", 10 ] ],
     "tools": [
-      [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ],
+      [ [ "sq_atomic_forge", -1 ] ],
       [ [ "sq_nanocomp", -1 ], [ "sq_nanoprint", -1 ], [ "sq_nanofab", -1 ] ]
     ],
     "components": [ [ [ "nanomaterial", 40 ] ], [ [ "alloy_sheet", 15 ] ] ]

--- a/BN/ProjectSquirrel/advtech/sq_vehicle_part.json
+++ b/BN/ProjectSquirrel/advtech/sq_vehicle_part.json
@@ -268,7 +268,7 @@
     "decomp_learn": 7,
 	"autolearn": true,
     "book_learn": [ [ "textbook_mechanics", 7 ], [ "textbook_electronics", 6 ], [ "advanced_electronics", 6 ], [ "textbook_robots", 5 ] ],
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "using": [ [ "soldering_standard", 50 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "recharge_station", 1 ] ], [ [ "power_supply", 2 ] ], [ [ "processor", 2 ] ], [ [ "scrap", 5 ] ], [ [ "cable", 8 ] ] ]
@@ -500,7 +500,7 @@
     "batch_time_factors": [ 50, 5 ],
     "book_learn": [ [ "recipe_lab_cvd", 7 ] ],
     "autolearn": false,
-    "tools": [ [ [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ] ],
+    "tools": [ [ [ "sq_atomic_forge", -1 ] ] ],
     "components": [ [ [ "carbide_plate", 12 ] ] ]
   },
   {

--- a/BN/ProjectSquirrel/obsoletion/migration.json
+++ b/BN/ProjectSquirrel/obsoletion/migration.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "sq_rtg_forge",
+    "type": "MIGRATION",
+    "replace": "sq_atomic_forge"
+  },
+  {
+    "id": "sq_uranium_forge",
+    "type": "MIGRATION",
+    "replace": "sq_atomic_forge"
+  },
+  {
+    "id": "sq_uranium_forge_done",
+    "type": "MIGRATION",
+    "replace": "sq_atomic_forge"
+  }
+]

--- a/BN/ProjectSquirrel/requirements/sq_requirements.json
+++ b/BN/ProjectSquirrel/requirements/sq_requirements.json
@@ -16,21 +16,21 @@
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for basic blacksmithing.  Permits working hot metal on stone surfaces.",
     "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "tongs", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ] ], [ [ "tongs", -1 ] ] ]
   },
   {
     "id": "blacksmithing_intermediate",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for mid-level blacksmithing.  Require a harder work surface for hot-cut chiseling and other uses of chisel quality.",
     "qualities": [ { "id": "ANVIL", "level": 2 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "tongs", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ] ], [ [ "tongs", -1 ] ] ]
   },
   {
     "id": "blacksmithing_advanced",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for advanced blacksmithing.  Require a proper dediciated anvil for use of a swage and die set.",
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ], [ "sq_rtg_forge", -1 ], [ "sq_uranium_forge", -1 ] ], [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ]
+    "tools": [ [ [ "forge", 20 ], [ "oxy_torch", 20 ], [ "sq_atomic_forge", -1 ] ], [ [ "tongs", -1 ] ], [ [ "swage", -1 ] ] ]
   },
   {
     "type": "material",


### PR DESCRIPTION
## 주요 제작도구 간소화
원자력 용광로 이후의 불필요하게 복잡하고 길었던 업그레이드 절차를 삭제했습니다.
다시말해, 이제 원자력 용광로는 업그레이드 하지 않아도 됩니다.
* 프로젝트: 다람쥐 1.1 버전의 핵심이었던 제작도구의 업그레이드는 처음에는 좋은 아이디어로 여겼으나, 결론적으로 불필요하게 플레이어의 자원 소모를 늘리고 게임을 늘어지게 하는 요소가 되었다고 봅니다. 따라서 1차적으로 용광로 트리의 도구를 모두 원자력 용광로 하나로 통합하기로 했습니다.
* 처음에는 레시피 오류가 뜨겠지만, 안심하세요. 한 번 실행 후 게임을 저장했다 다시 해보면 해결될겁니다.