### PR TITLE
fix: `freezing_point` 필드 제거

### DIFF
--- a/BN/ProjectSquirrel/advtech/sq_meds.json
+++ b/BN/ProjectSquirrel/advtech/sq_meds.json
@@ -134,7 +134,6 @@
     "calories": 104,
     "quench": 15,
     "fun": 1,
-    "freezing_point": -49,
     "addiction_potential": 3,
     "use_action": {
       "type": "consume_drug",
@@ -197,7 +196,6 @@
     "calories": 222,
     "quench": -8,
     "fun": -5,
-    "freezing_point": -89,
     "addiction_potential": 7,
     "use_action": {
       "type": "consume_drug",

--- a/BN/SF_Weapons/Contents/calorie_pill.json
+++ b/BN/SF_Weapons/Contents/calorie_pill.json
@@ -15,7 +15,6 @@
     "charges": 1,
     "looks_like": "vitamins",
     "fun": -10,
-    "freezing_point": -490,
     "vitamins": [
       [ "calcium", 24, 48 ],
       [ "iron", 24, 48 ],

--- a/DDA/포탈가챠 1.10.2(안정판0.G 대응)/GATCHA_Portal/EVENT/cm.json
+++ b/DDA/포탈가챠 1.10.2(안정판0.G 대응)/GATCHA_Portal/EVENT/cm.json
@@ -20,7 +20,6 @@
 		"phase":"liquid",
 		"charges":1,
 		"fun":70,
-		"freezing_point":-70,
 		"flags":[ "TRADER_AVOID","EATEN_HOT","EATEN_COLD" ]
 	}
 ,
@@ -52,7 +51,6 @@
 		"volume":"200 ml",
 		"spoils_in":"360 days",
 		"fun":70,
-		"freezing_point":0,
 		"flags":[ "TRADER_AVOID","EATEN_HOT" ]
 	}
 ,
@@ -73,7 +71,6 @@
 		"volume":"200 ml",
 		"spoils_in":"360 days",
 		"fun":70,
-		"freezing_point":0,
 		"flags":[ "TRADER_AVOID","EATEN_HOT" ]
 	}
 


### PR DESCRIPTION
해당 필드가 https://github.com/cataclysmbnteam/Cataclysm-BN/pull/3926 에서 완전히 제거되며 발생한 오류 메시지 해결