### PR TITLE
히트 블레이드에 revert_to 필드 추가

### DIFF
--- a/BN/ProjectSquirrel/advtech/sq_nano_tier.json
+++ b/BN/ProjectSquirrel/advtech/sq_nano_tier.json
@@ -1150,6 +1150,8 @@
     "looks_like": "sword_xiphos",
     "color": "red",
     "power_draw": 25000,
+    "revert_to": "sq_heat_blade_off",
+    "revert_msg":"히트 블레이드가 꺼졌습니다.",
     "techniques": [ "WBLOCK_2" ],
     "use_action": {
       "type": "transform",


### PR DESCRIPTION
이제 히트 블레이드는 배터리가 다 되어도 사라지지 않고 정상적으로 원래대로 돌아옵니다.

The heat blade will now return to normal instead of disappearing when the battery runs out.
