### PR TITLE
fix: damage_type `none` -> `true` 로 변경

### DIFF
--- a/BN/CBM++64/weapon/effect.json
+++ b/BN/CBM++64/weapon/effect.json
@@ -17,7 +17,7 @@
 	"sound_id": "misc",                                       
 	"sound_variant": "shockwave",
     "flags": [ "SILENT","NO_HANDS","NO_LEGS","NO_FAIL"],
-    "damage_type": "none"
+    "damage_type": "true"
   },{
     "id": "Claw_du", 
 	"type": "SPELL",
@@ -36,7 +36,7 @@
 	"sound_id": "misc",                                       
 	"sound_variant": "shockwave",
     "flags": [ "SILENT","NO_HANDS","NO_LEGS","NO_FAIL"],
-    "damage_type": "none"
+    "damage_type": "true"
   },{
 	   "id": "ench_climate_EX", 
 		"type": "enchantment",
@@ -71,7 +71,7 @@
 	"sound_id": "misc",                                       
 	"sound_variant": "shockwave",
     "flags": [ "SILENT","NO_HANDS","NO_LEGS","NO_FAIL"],
-    "damage_type": "none"
+    "damage_type": "true"
   },{
 "type": "effect_type",
     "id": "Sandevistan",


### PR DESCRIPTION
더 이상 쓰지 않는 대미지 타입 none을 true로 변경했습니다.